### PR TITLE
Implement `Writing` on `Router`

### DIFF
--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -25,7 +25,7 @@ use snarkos_node_messages::{
     MessageCodec,
     MessageTrait,
 };
-use snarkos_node_tcp::{ConnectionSide, Tcp, P2P};
+use snarkos_node_tcp::ConnectionSide;
 use snarkvm::prelude::{error, Address, Header, Network};
 
 use anyhow::{bail, Result};
@@ -35,13 +35,6 @@ use std::{io, net::SocketAddr};
 use tokio::net::TcpStream;
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
-
-impl<N: Network> P2P for Router<N> {
-    /// Returns a reference to the TCP instance.
-    fn tcp(&self) -> &Tcp {
-        &self.tcp
-    }
-}
 
 impl<N: Network> Router<N> {
     /// Performs the handshake protocol.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -40,8 +40,8 @@ mod routing;
 pub use routing::*;
 
 use snarkos_account::Account;
-use snarkos_node_messages::NodeType;
-use snarkos_node_tcp::{Config, Tcp};
+use snarkos_node_messages::{Message, MessageCodec, NodeType};
+use snarkos_node_tcp::{protocols::Writing, Config, ConnectionSide, Tcp, P2P};
 use snarkvm::prelude::{Address, Network, PrivateKey, ViewKey};
 
 use anyhow::{bail, Result};
@@ -92,6 +92,28 @@ pub struct InnerRouter<N: Network> {
     handles: RwLock<Vec<JoinHandle<()>>>,
     /// The boolean flag for the development mode.
     is_dev: bool,
+}
+
+// Implement some of the Tcp traits at this level to allow propagating messages through the router
+// in the BFT. Note: these traits are also implemented at the node level.
+impl<N: Network> P2P for Router<N> {
+    /// Returns a reference to the TCP instance.
+    fn tcp(&self) -> &Tcp {
+        &self.tcp
+    }
+}
+
+// Only Writing is included here, since Reading and Handshake depend on node-level objects.
+#[async_trait]
+impl<N: Network> Writing for Router<N> {
+    type Codec = MessageCodec<N>;
+    type Message = Message<N>;
+
+    /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
+    /// The `side` parameter indicates the connection side **from the node's perspective**.
+    fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
+        Default::default()
+    }
 }
 
 impl<N: Network> Router<N> {


### PR DESCRIPTION
Allows the BFT to propagate through the `Router` and avoids a circular dependency on the node crate. BFT can now depend only on the router subcrate.