### PR TITLE
Use Aleo paths for BFT-related storage (primaries and workers)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4919,6 +4919,7 @@ dependencies = [
 name = "snarkos-node-bft-consensus"
 version = "0.1.0"
 dependencies = [
+ "aleo-std",
  "anyhow",
  "arc-swap",
  "async-trait",

--- a/node/bft-consensus/Cargo.toml
+++ b/node/bft-consensus/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+aleo-std = "0.1.15"
 async-trait = "0.1"
 bincode = "1"
 bytes = "1"

--- a/node/bft-consensus/src/lib.rs
+++ b/node/bft-consensus/src/lib.rs
@@ -62,9 +62,9 @@ pub enum BftError {
     EyreReport(String),
 }
 
-fn primary_dir(network: u16, dev: Option<u16>) -> PathBuf {
+fn base_path(dev: Option<u16>) -> PathBuf {
     // Retrieve the starting directory.
-    let mut path = match dev.is_some() {
+    match dev.is_some() {
         // In development mode, the ledger is stored in the repository root directory.
         true => match std::env::current_dir() {
             Ok(current_dir) => current_dir,
@@ -72,7 +72,11 @@ fn primary_dir(network: u16, dev: Option<u16>) -> PathBuf {
         },
         // In production mode, the ledger is stored in the `~/.aleo/` directory.
         false => aleo_dir(),
-    };
+    }
+}
+
+fn primary_dir(network: u16, dev: Option<u16>) -> PathBuf {
+    let mut path = base_path(dev);
 
     // Construct the path to the ledger in storage.
     //
@@ -94,15 +98,7 @@ fn primary_dir(network: u16, dev: Option<u16>) -> PathBuf {
 
 fn worker_dir(network: u16, worker_id: u32, dev: Option<u16>) -> PathBuf {
     // Retrieve the starting directory.
-    let mut path = match dev.is_some() {
-        // In development mode, the ledger is stored in the repository root directory.
-        true => match std::env::current_dir() {
-            Ok(current_dir) => current_dir,
-            _ => PathBuf::from(env!("CARGO_MANIFEST_DIR")),
-        },
-        // In production mode, the ledger is stored in the `~/.aleo/` directory.
-        false => aleo_dir(),
-    };
+    let mut path = base_path(dev);
 
     // Construct the path to the ledger in storage.
     //

--- a/node/bft-consensus/src/lib.rs
+++ b/node/bft-consensus/src/lib.rs
@@ -81,10 +81,11 @@ fn primary_dir(network: u16, dev: Option<u16>) -> PathBuf {
     // Construct the path to the ledger in storage.
     //
     // Prod: `~/.aleo/storage/bft-primary-{network}`
-    // Dev: `path/to/repo/.bft-primary-{network}-{id}`
+    // Dev: `path/to/repo/.bft-{network}/primary-{id}`
     match dev {
         Some(id) => {
-            path.push(format!(".bft-primary-{network}-{id}"));
+            path.push(format!(".bft-{network}"));
+            path.push(format!("primary-{id}"));
         }
 
         None => {
@@ -103,10 +104,11 @@ fn worker_dir(network: u16, worker_id: u32, dev: Option<u16>) -> PathBuf {
     // Construct the path to the ledger in storage.
     //
     // Prod: `~/.aleo/storage/bft-worker-{network}-{worker_id}`
-    // Dev: `path/to/repo/.bft-worker-{network}-{primary_id}-{worker_id}`
+    // Dev: `path/to/repo/.bft-{network}/worker-{primary_id}-{worker_id}`
     match dev {
         Some(primary_id) => {
-            path.push(format!(".bft-worker-{network}-{primary_id}-{worker_id}"));
+            path.push(format!(".bft-{network}"));
+            path.push(format!("worker-{primary_id}-{worker_id}"));
         }
 
         None => {

--- a/node/bft-consensus/src/lib.rs
+++ b/node/bft-consensus/src/lib.rs
@@ -65,7 +65,7 @@ pub enum BftError {
 fn base_path(dev: Option<u16>) -> PathBuf {
     // Retrieve the starting directory.
     match dev.is_some() {
-        // In development mode, the ledger is stored in the repository root directory.
+        // In development mode, the ledger is stored in the root directory of the repository.
         true => match std::env::current_dir() {
             Ok(current_dir) => current_dir,
             _ => PathBuf::from(env!("CARGO_MANIFEST_DIR")),

--- a/node/bft-consensus/src/lib.rs
+++ b/node/bft-consensus/src/lib.rs
@@ -103,7 +103,7 @@ fn worker_dir(network: u16, worker_id: u32, dev: Option<u16>) -> PathBuf {
     // Construct the path to the ledger in storage.
     //
     // Prod: `~/.aleo/storage/bft-worker-{network}-{worker_id}`
-    // Dev: `path/to/repo/.bft-primary-{network}-{primary_id}-{worker_id}`
+    // Dev: `path/to/repo/.bft-worker-{network}-{primary_id}-{worker_id}`
     match dev {
         Some(primary_id) => {
             path.push(format!(".bft-worker-{network}-{primary_id}-{worker_id}"));

--- a/node/bft-consensus/src/lib.rs
+++ b/node/bft-consensus/src/lib.rs
@@ -80,7 +80,7 @@ fn primary_dir(network: u16, dev: Option<u16>) -> PathBuf {
 
     // Construct the path to the ledger in storage.
     //
-    // Prod: `~/.aleo/storage/bft-primary-{network}`
+    // Prod: `~/.aleo/storage/bft-{network}/primary`
     // Dev: `path/to/repo/.bft-{network}/primary-{id}`
     match dev {
         Some(id) => {
@@ -90,7 +90,8 @@ fn primary_dir(network: u16, dev: Option<u16>) -> PathBuf {
 
         None => {
             path.push("storage");
-            path.push(format!("bft-primary-{network}"));
+            path.push(format!("bft-{network}"));
+            path.push(format!("primary"));
         }
     }
 
@@ -103,7 +104,7 @@ fn worker_dir(network: u16, worker_id: u32, dev: Option<u16>) -> PathBuf {
 
     // Construct the path to the ledger in storage.
     //
-    // Prod: `~/.aleo/storage/bft-worker-{network}-{worker_id}`
+    // Prod: `~/.aleo/storage/bft-{network}/worker-{worker_id}`
     // Dev: `path/to/repo/.bft-{network}/worker-{primary_id}-{worker_id}`
     match dev {
         Some(primary_id) => {
@@ -113,7 +114,8 @@ fn worker_dir(network: u16, worker_id: u32, dev: Option<u16>) -> PathBuf {
 
         None => {
             path.push("storage");
-            path.push(format!("bft-worker-{network}-{worker_id}"));
+            path.push(format!("bft-{network}"));
+            path.push(format!("worker-{worker_id}"));
         }
     }
 

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -116,9 +116,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         node.handle_signals();
 
         // Start the BFT consensus here
-        // TODO: this port trick only works in dev mode?
-        let id = dev.unwrap() - 1;
-        let bft = BftConsensus::new(id as u32, consensus, router)?;
+        let bft = BftConsensus::new(consensus, router, dev)?;
         let (primary, worker) = bft.start().await.unwrap();
 
         // Start the primary.


### PR DESCRIPTION
Some of this logic could likely be moved to `aleo-std` at some point. 