### PR TITLE
Introduce a basic setup for consensus tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4942,10 +4942,12 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-tcp",
  "snarkvm",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber 0.3.16",
 ]
 
 [[package]]

--- a/node/bft-consensus/Cargo.toml
+++ b/node/bft-consensus/Cargo.toml
@@ -33,3 +33,7 @@ arc-swap = "1.5.1"
 eyre = "0.6.8"
 anyhow = "1"
 thiserror = "1.0.38"
+
+[dev-dependencies]
+tempfile = "3"
+tracing-subscriber = "0.3"

--- a/node/bft-consensus/src/lib.rs
+++ b/node/bft-consensus/src/lib.rs
@@ -91,7 +91,7 @@ fn primary_dir(network: u16, dev: Option<u16>) -> PathBuf {
         None => {
             path.push("storage");
             path.push(format!("bft-{network}"));
-            path.push(format!("primary"));
+            path.push("primary");
         }
     }
 

--- a/node/bft-consensus/src/lib.rs
+++ b/node/bft-consensus/src/lib.rs
@@ -374,13 +374,13 @@ impl<N: Network, C: ConsensusStorage<N>> ExecutionState for BftExecutionState<N,
     }
 }
 
-fn read_network_keypair_from_file<P: AsRef<std::path::Path>>(path: P) -> anyhow::Result<Ed25519KeyPair> {
+pub fn read_network_keypair_from_file<P: AsRef<std::path::Path>>(path: P) -> anyhow::Result<Ed25519KeyPair> {
     let contents = std::fs::read_to_string(path)?;
     let bytes = Base64::decode(contents.as_str()).map_err(|e| anyhow!("{}", e.to_string()))?;
     Ed25519KeyPair::from_bytes(bytes.get(1..).unwrap()).map_err(|e| anyhow!(e))
 }
 
-fn read_authority_keypair_from_file<P: AsRef<std::path::Path>>(path: P) -> anyhow::Result<BLS12381KeyPair> {
+pub fn read_authority_keypair_from_file<P: AsRef<std::path::Path>>(path: P) -> anyhow::Result<BLS12381KeyPair> {
     let contents = std::fs::read_to_string(path)?;
     BLS12381KeyPair::decode_base64(contents.as_str().trim()).map_err(|e| anyhow!(e))
 }

--- a/node/bft-consensus/tests/basics.rs
+++ b/node/bft-consensus/tests/basics.rs
@@ -1,0 +1,37 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use tracing_subscriber::filter::LevelFilter;
+
+mod common;
+
+use common::{start_logger, TestBftConsensus};
+
+#[tokio::test]
+async fn foo() {
+    start_logger(LevelFilter::DEBUG);
+
+    const N_MEMBERS: u8 = 4;
+
+    let mut members = Vec::with_capacity(N_MEMBERS as usize);
+    for i in 0..N_MEMBERS {
+        let consensus = TestBftConsensus::new(i).unwrap();
+        let member = consensus.start().await.unwrap();
+        members.push(member);
+    }
+
+    // TODO: extend to something useful and rename
+}

--- a/node/bft-consensus/tests/common/mod.rs
+++ b/node/bft-consensus/tests/common/mod.rs
@@ -1,0 +1,43 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+mod objects;
+mod state;
+mod transaction;
+mod validation;
+
+pub use objects::*;
+pub use state::*;
+pub use transaction::*;
+pub use validation::*;
+
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+
+pub fn start_logger(default_level: LevelFilter) {
+    let filter = match EnvFilter::try_from_default_env() {
+        Ok(filter) => filter
+            .add_directive("anemo=off".parse().unwrap())
+            .add_directive("rustls=off".parse().unwrap())
+            .add_directive("tokio_util=off".parse().unwrap()),
+        _ => EnvFilter::default()
+            .add_directive(default_level.into())
+            .add_directive("anemo=off".parse().unwrap())
+            .add_directive("rustls=off".parse().unwrap())
+            .add_directive("tokio_util=off".parse().unwrap()),
+    };
+
+    tracing_subscriber::fmt().with_env_filter(filter).with_target(true).init();
+}

--- a/node/bft-consensus/tests/common/objects.rs
+++ b/node/bft-consensus/tests/common/objects.rs
@@ -1,0 +1,148 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::Result;
+use arc_swap::ArcSwap;
+use fastcrypto::{bls12381::min_sig::BLS12381KeyPair, traits::KeyPair};
+use narwhal_config::{Committee, Import, Parameters, WorkerCache};
+use narwhal_crypto::NetworkKeyPair;
+use narwhal_node::{primary_node::PrimaryNode, worker_node::WorkerNode, NodeStorage};
+use tempfile::TempDir;
+
+use snarkos_node_bft_consensus::{read_authority_keypair_from_file, read_network_keypair_from_file};
+
+use super::{state::TestBftExecutionState, validation::TestTransactionValidator};
+
+pub struct TestBftConsensus {
+    primary_id: u8,
+    primary_keypair: BLS12381KeyPair,
+    network_keypair: NetworkKeyPair,
+    worker_keypair: NetworkKeyPair,
+    parameters: Parameters,
+    primary_store: NodeStorage,
+    worker_store: NodeStorage,
+    committee: Arc<ArcSwap<Committee>>,
+    worker_cache: Arc<ArcSwap<WorkerCache>>,
+    storage_dir: TempDir,
+}
+
+#[allow(dead_code)]
+pub struct Member {
+    primary_id: u8,
+    primary_node: PrimaryNode,
+    worker_node: WorkerNode,
+    storage_dir: TempDir,
+}
+
+fn primary_dir(base_path: &Path, primary_id: u8) -> PathBuf {
+    let mut path = base_path.to_owned();
+
+    path.push(".bft");
+    path.push(format!("primary-{primary_id}"));
+
+    path
+}
+
+fn worker_dir(base_path: &Path, primary_id: u8, worker_id: u8) -> PathBuf {
+    let mut path = base_path.to_owned();
+
+    path.push(".bft");
+    path.push(format!("worker-{primary_id}-{worker_id}"));
+
+    path
+}
+
+impl TestBftConsensus {
+    pub fn new(primary_id: u8) -> Result<Self> {
+        let primary_key_file = format!("{}/.primary-{primary_id}-key.json", env!("CARGO_MANIFEST_DIR"));
+        let primary_keypair = read_authority_keypair_from_file(primary_key_file).unwrap();
+        let primary_network_key_file = format!("{}/.primary-{primary_id}-network-key.json", env!("CARGO_MANIFEST_DIR"));
+        let network_keypair = read_network_keypair_from_file(primary_network_key_file).unwrap();
+        let worker_key_file = format!("{}/.worker-{primary_id}-key.json", env!("CARGO_MANIFEST_DIR"));
+        let worker_keypair = read_network_keypair_from_file(worker_key_file).unwrap();
+        let committee_file = format!("{}/.committee.json", env!("CARGO_MANIFEST_DIR"));
+        let committee = Arc::new(ArcSwap::from_pointee(Committee::import(&committee_file).unwrap()));
+        let workers_file = format!("{}/.workers.json", env!("CARGO_MANIFEST_DIR"));
+        let worker_cache = Arc::new(ArcSwap::from_pointee(WorkerCache::import(&workers_file).unwrap()));
+
+        let filename = format!("{}/.parameters.json", env!("CARGO_MANIFEST_DIR"));
+        let parameters = Parameters::import(&filename).unwrap();
+
+        let storage_dir = TempDir::new().unwrap();
+        let base_path = storage_dir.path();
+
+        let primary_store_path = primary_dir(base_path, primary_id);
+        let primary_store = NodeStorage::reopen(primary_store_path);
+        let worker_store_path = worker_dir(base_path, primary_id, 0);
+        let worker_store = NodeStorage::reopen(worker_store_path);
+
+        Ok(Self {
+            primary_id,
+            primary_keypair,
+            network_keypair,
+            worker_keypair,
+            parameters,
+            primary_store,
+            worker_store,
+            committee,
+            worker_cache,
+            storage_dir,
+        })
+    }
+
+    pub async fn start(self) -> Result<Member> {
+        let primary_pub = self.primary_keypair.public().clone();
+        let primary = PrimaryNode::new(self.parameters.clone(), true);
+        let bft_execution_state = TestBftExecutionState::default();
+
+        primary
+            .start(
+                self.primary_keypair,
+                self.network_keypair,
+                self.committee.clone(),
+                self.worker_cache.clone(),
+                &self.primary_store,
+                Arc::new(bft_execution_state),
+            )
+            .await?;
+
+        let worker = WorkerNode::new(0, self.parameters.clone());
+        worker
+            .start(
+                primary_pub,
+                self.worker_keypair,
+                self.committee.clone(),
+                self.worker_cache,
+                &self.worker_store,
+                TestTransactionValidator::default(),
+            )
+            .await?;
+
+        let member = Member {
+            primary_id: self.primary_id,
+            primary_node: primary,
+            worker_node: worker,
+            storage_dir: self.storage_dir,
+        };
+
+        Ok(member)
+    }
+}

--- a/node/bft-consensus/tests/common/state.rs
+++ b/node/bft-consensus/tests/common/state.rs
@@ -1,0 +1,32 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use async_trait::async_trait;
+use narwhal_executor::ExecutionState;
+use narwhal_types::ConsensusOutput;
+
+// TODO: come up with some useful state to alter and test via consensus
+#[derive(Default)]
+pub struct TestBftExecutionState;
+
+#[async_trait]
+impl ExecutionState for TestBftExecutionState {
+    async fn handle_consensus_output(&self, _consensus_output: ConsensusOutput) {}
+
+    async fn last_executed_sub_dag_index(&self) -> u64 {
+        0
+    }
+}

--- a/node/bft-consensus/tests/common/transaction.rs
+++ b/node/bft-consensus/tests/common/transaction.rs
@@ -1,0 +1,19 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+// TODO: come up with some useful tx types for consensus property testing
+#[allow(dead_code)]
+enum Transaction {}

--- a/node/bft-consensus/tests/common/validation.rs
+++ b/node/bft-consensus/tests/common/validation.rs
@@ -1,0 +1,33 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use narwhal_types::Batch;
+
+#[derive(Default, Clone)]
+pub struct TestTransactionValidator;
+
+impl narwhal_worker::TransactionValidator for TestTransactionValidator {
+    type Error = anyhow::Error;
+
+    fn validate(&self, _transaction: &[u8]) -> Result<(), Self::Error> {
+        // TODO: come up with some useful validation criteria
+        Ok(())
+    }
+
+    fn validate_batch(&self, _batch: &Batch) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Putting it out there already due to the diff; much of the code was copied from the `bft-consensus` main module, with tweaks making the setup self-contained.