### PR TITLE
Allow multiple workers per primary (sort of)

### DIFF
--- a/node/bft-consensus/tests/common/mod.rs
+++ b/node/bft-consensus/tests/common/mod.rs
@@ -32,12 +32,14 @@ pub fn start_logger(default_level: LevelFilter) {
     let filter = match EnvFilter::try_from_default_env() {
         Ok(filter) => filter
             .add_directive("anemo=off".parse().unwrap())
+            .add_directive("narwhal_config=off".parse().unwrap())
             .add_directive("rustls=off".parse().unwrap())
             .add_directive("tokio_util=off".parse().unwrap())
             .add_directive("typed_store=off".parse().unwrap()),
         _ => EnvFilter::default()
             .add_directive(default_level.into())
             .add_directive("anemo=off".parse().unwrap())
+            .add_directive("narwhal_config=off".parse().unwrap())
             .add_directive("rustls=off".parse().unwrap())
             .add_directive("tokio_util=off".parse().unwrap())
             .add_directive("typed_store=off".parse().unwrap()),


### PR DESCRIPTION
This PR provides all that is needed to run multiple workers per a primary; while it doesn't work yet due to `bullshark-bft` not supporting this (though it would be relatively simple to adjust it to do so), it's unlikely to be useful in local tests; what is more useful is having all the relevant objects in place to later be able to use it outside of tests.