### PR TITLE
Add a primary failure test

### DIFF
--- a/node/bft-consensus/tests/common/objects.rs
+++ b/node/bft-consensus/tests/common/objects.rs
@@ -80,9 +80,8 @@ impl InertConsensusInstance {
     }
 }
 
-#[allow(dead_code)]
 pub struct RunningConsensusInstance {
-    primary_node: PrimaryNode,
-    worker_nodes: Vec<WorkerNode>,
+    pub primary_node: PrimaryNode,
+    pub worker_nodes: Vec<WorkerNode>,
     pub state: Arc<TestBftExecutionState>,
 }

--- a/node/bft-consensus/tests/common/state.rs
+++ b/node/bft-consensus/tests/common/state.rs
@@ -29,7 +29,7 @@ pub type Address = String;
 pub type Amount = u64;
 
 pub struct TestBftExecutionState {
-    balances: Mutex<HashMap<Address, Amount>>,
+    pub balances: Mutex<HashMap<Address, Amount>>,
 }
 
 impl Clone for TestBftExecutionState {


### PR DESCRIPTION
This new test case ensures that the consensus can still progress with 1 of 4 primaries failing, and that it stops as soon as the second one fails.