### PR TITLE
Check transaction order in blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4802,6 +4802,7 @@ dependencies = [
  "indexmap",
  "narwhal-types",
  "num_cpus",
+ "once_cell",
  "parking_lot",
  "pea2pea",
  "rand",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -53,6 +53,9 @@ version = "1"
 [dependencies.num_cpus]
 version = "1"
 
+[dependencies.once_cell]
+version = "1"
+
 [dependencies.parking_lot]
 version = "0.12"
 

--- a/node/bft-consensus/Cargo.toml
+++ b/node/bft-consensus/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1"
 bincode = "1"
 bytes = "1"
 multiaddr = "0.17"
+parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt"] }
 tonic = "0.8"

--- a/node/bft-consensus/src/lib.rs
+++ b/node/bft-consensus/src/lib.rs
@@ -20,7 +20,7 @@ mod validation;
 
 use setup::*;
 
-pub use state::BftExecutionState;
+pub use state::{sort_transactions, BftExecutionState};
 pub use validation::TransactionValidator;
 
 use anyhow::Result;

--- a/node/bft-consensus/src/state.rs
+++ b/node/bft-consensus/src/state.rs
@@ -14,12 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::{collections::HashMap, sync::Arc};
+
 use anyhow::bail;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use fastcrypto::bls12381::min_sig::BLS12381PublicKey;
 use narwhal_executor::ExecutionState;
 use narwhal_types::ConsensusOutput;
+use parking_lot::Mutex;
 use tracing::*;
 
 use snarkos_node_consensus::Consensus as AleoConsensus;
@@ -34,11 +37,12 @@ pub struct BftExecutionState<N: Network, C: ConsensusStorage<N>> {
     primary_pub: BLS12381PublicKey,
     router: Router<N>,
     consensus: AleoConsensus<N, C>,
+    pub last_output: Arc<Mutex<Option<ConsensusOutput>>>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> BftExecutionState<N, C> {
     pub fn new(primary_pub: BLS12381PublicKey, router: Router<N>, consensus: AleoConsensus<N, C>) -> Self {
-        Self { primary_pub, router, consensus }
+        Self { primary_pub, router, consensus, last_output: Default::default() }
     }
 }
 
@@ -46,6 +50,8 @@ impl<N: Network, C: ConsensusStorage<N>> BftExecutionState<N, C> {
 impl<N: Network, C: ConsensusStorage<N>> ExecutionState for BftExecutionState<N, C> {
     /// Receive the consensus result with the ordered transactions in `ConsensusOutupt`
     async fn handle_consensus_output(&self, consensus_output: ConsensusOutput) {
+        *self.last_output.lock() = Some(consensus_output.clone());
+
         let leader = &consensus_output.sub_dag.leader.header.author;
         let mut leader_id = leader.to_string();
         leader_id.truncate(8);
@@ -77,7 +83,7 @@ impl<N: Network, C: ConsensusStorage<N>> ExecutionState for BftExecutionState<N,
         let private_key = *self.router.private_key();
         let next_block = tokio::task::spawn_blocking(move || {
             // Collect all the transactions contained in the agreed upon batches.
-            let mut transactions = Vec::new();
+            let mut transactions = HashMap::new();
             for batch in consensus_output.batches {
                 for batch in batch.1 {
                     for transaction in batch.transactions {
@@ -85,25 +91,29 @@ impl<N: Network, C: ConsensusStorage<N>> ExecutionState for BftExecutionState<N,
                         // TransactionValidator ensures that the Message can be deserialized.
                         let message = Message::<N>::deserialize(bytes).unwrap();
 
-                        let unconfirmed_transaction =
-                            if let Message::UnconfirmedTransaction(unconfirmed_transaction) = message {
-                                unconfirmed_transaction
-                            } else {
-                                // TransactionValidator ensures that the Message is an UnconfirmedTransaction.
-                                unreachable!();
-                            };
+                        let unconfirmed_tx = if let Message::UnconfirmedTransaction(tx) = message {
+                            tx
+                        } else {
+                            // TransactionValidator ensures that the Message is an UnconfirmedTransaction.
+                            unreachable!();
+                        };
 
                         // TransactionValidator ensures that the Message can be deserialized.
-                        let transaction = unconfirmed_transaction.transaction.deserialize_blocking().unwrap();
+                        let tx = unconfirmed_tx.transaction.deserialize_blocking().unwrap();
 
-                        transactions.push(transaction);
+                        transactions.insert(tx.id(), tx);
                     }
                 }
             }
 
-            // Attempt to add the batched transactions to the Aleo mempool.
+            // Sort the transactions by ID according to shared logic.
+            let mut sorted_tx_ids = transactions.keys().copied().collect::<Vec<_>>();
+            sort_transactions::<N>(&mut sorted_tx_ids);
+
+            // Attempt to add the batched transactions to the Aleo mempool in a strict order.
             let mut num_valid_txs = 0;
-            for transaction in transactions {
+            for id in &sorted_tx_ids {
+                let transaction = transactions.remove(id).unwrap(); // guaranteed to be there
                 // Skip invalid transactions.
                 if consensus.add_unconfirmed_transaction(transaction).is_ok() {
                     num_valid_txs += 1;
@@ -186,4 +196,10 @@ impl<N: Network, C: ConsensusStorage<N>> ExecutionState for BftExecutionState<N,
         // TODO: this seems like a potential optimization, but shouldn't be needed
         0
     }
+}
+
+// A sorting logic shared among all the validators.
+pub fn sort_transactions<N: Network>(transaction_ids: &mut [N::TransactionID]) {
+    // TODO: possibly sort using a more elaborate logic
+    transaction_ids.sort_by_key(|id| id.to_string());
 }

--- a/node/consensus/src/memory_pool/mod.rs
+++ b/node/consensus/src/memory_pool/mod.rs
@@ -21,6 +21,7 @@ use crate::{anchor_block_height, Consensus};
 use snarkvm::prelude::{ConsensusStorage, Itertools, Network, ProverSolution, PuzzleCommitment, Transaction};
 
 use anyhow::{anyhow, Result};
+use indexmap::IndexMap;
 use parking_lot::RwLock;
 use std::{collections::HashMap, sync::Arc};
 
@@ -28,7 +29,7 @@ use std::{collections::HashMap, sync::Arc};
 #[allow(clippy::type_complexity)]
 pub struct MemoryPool<N: Network> {
     /// The pool of unconfirmed transactions.
-    unconfirmed_transactions: Arc<RwLock<HashMap<N::TransactionID, Transaction<N>>>>,
+    unconfirmed_transactions: Arc<RwLock<IndexMap<N::TransactionID, Transaction<N>>>>,
     /// The pool of unconfirmed solutions and their proof targets.
     unconfirmed_solutions: Arc<RwLock<HashMap<PuzzleCommitment<N>, (ProverSolution<N>, u64)>>>,
 }

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -189,7 +189,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
     /// Return the BFT consensus handle.
     pub fn bft(&self) -> &RunningConsensusInstance<BftExecutionState<N, C>> {
         // Safe: it is used only once it's populated.
-        self.bft.get().unwrap()
+        self.bft.get().expect("Logic bug: Validator::bft didn't find a RunningConsensusInstance!")
     }
 
     #[cfg(feature = "test")]


### PR DESCRIPTION
This PR makes all the validators remember the result of the consensus and able to tell what the order of transactions should be, in order to verify it in the block produced by the leader.