### PR TITLE
Make the primary failure test more flexible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4837,6 +4837,7 @@ dependencies = [
  "async-trait",
  "bincode 1.3.3",
  "bytes",
+ "deadline",
  "fastcrypto",
  "multiaddr",
  "narwhal-config",

--- a/node/bft-consensus/Cargo.toml
+++ b/node/bft-consensus/Cargo.toml
@@ -37,6 +37,7 @@ arc-swap = "1.5.1"
 anyhow = "1"
 
 [dev-dependencies]
+deadline = "0.2"
 parking_lot = "0.12"
 tempfile = "3"
 tracing-subscriber = "0.3"

--- a/node/bft-consensus/tests/basics.rs
+++ b/node/bft-consensus/tests/basics.rs
@@ -17,9 +17,11 @@
 use std::{sync::atomic::Ordering, time::Duration};
 
 use bytes::Bytes;
+use deadline::deadline;
 use narwhal_types::TransactionProto;
 use rand::prelude::{thread_rng, IteratorRandom, Rng};
 use snarkvm::prelude::TestRng;
+use tokio::time::{sleep, timeout};
 
 mod common;
 
@@ -85,7 +87,7 @@ async fn verify_state_coherence() {
     }
 
     // Wait for a while to allow the transfers to be processed.
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    sleep(Duration::from_secs(3)).await;
 
     // Check that all the states match.
     let first_state = &running_consensus_instances[0].state;
@@ -94,20 +96,22 @@ async fn verify_state_coherence() {
     }
 }
 
-// Ensures that a 4-member committee can survive a single member failure,
+// Ensures that a committee can survive the expected number of member failures,
 // and that it ceases to function with a single additional failure.
 #[tokio::test(flavor = "multi_thread")]
 async fn primary_failures() {
-    // TODO: while this test is currently hardcoded to 4 primaries and 30
-    // txs, there's no reason why it couldn't work for any number of them,
-    // but it would require a bit of extra work.
-
     // Configure the primary-related variables.
-    const NUM_PRIMARIES: usize = 4; // this shouldn't be altered on its own
+    const NUM_PRIMARIES: usize = 5;
+    // TODO: extend the test to different stakes
     const PRIMARY_STAKE: u64 = 1;
 
-    // Configure the transactions.
-    const NUM_TRANSACTIONS: usize = 30; // this shouldn't be altered on its own
+    // Calculate the maximum allowed number of primary failures.
+    // note: it's the number of primaries minus the quorum
+    const MAX_FAILURES: usize = NUM_PRIMARIES - (2 * NUM_PRIMARIES / 3 + 1);
+
+    // Configure the transaction counts.
+    const NUM_TXS_PER_ITER: usize = 5;
+    const NUM_TRANSACTIONS: usize = (MAX_FAILURES + 2) * NUM_TXS_PER_ITER;
 
     // Prepare a source of randomness for key generation.
     let mut rng = thread_rng();
@@ -123,6 +127,12 @@ async fn primary_failures() {
     // Prepare the initial state.
     let state = TestBftExecutionState::default();
 
+    // Use a deterministic Rng for transaction generation.
+    let mut rng = TestRng::default();
+
+    // Generate random transactions.
+    let mut transfers = state.generate_random_transfers(NUM_TRANSACTIONS, &mut rng);
+
     // Create the preconfigured consensus instances.
     let inert_consensus_instances = generate_consensus_instances(committee, state.clone());
 
@@ -136,94 +146,68 @@ async fn primary_failures() {
     // Create transaction clients; any instance can be used to do that.
     let mut tx_clients = running_consensus_instances[0].spawn_tx_clients();
 
-    // Use a deterministic Rng for transaction generation.
-    let mut rng = TestRng::default();
+    // We stop when the consensus ceases to function (the timeout).
+    for i in 0.. {
+        // Save the number of processed transactions before the next batch is distributed.
+        // note: in the first iteration it's zero for everyone, and later on it's guaranteed
+        // to be coherent due to us waiting for the numbers to be aligned for everyone.
+        let tx_count_before_batch = running_consensus_instances[0].state.processed_txs.load(Ordering::SeqCst);
 
-    // Generate random transactions.
-    let transfers = state.generate_random_transfers(NUM_TRANSACTIONS, &mut rng);
+        // Prepare a batch of transactions to be sent to the workers.
+        let tx_batch = transfers
+            .drain(..NUM_TXS_PER_ITER)
+            .map(|tx| {
+                let transaction: Bytes = bincode::serialize(&tx).unwrap().into();
+                TransactionProto { transaction }
+            })
+            .collect::<Vec<_>>();
 
-    // Send a third of the transactions to the workers.
-    for transfer in &transfers[..10] {
-        let transaction: Bytes = bincode::serialize(&transfer).unwrap().into();
-        let tx = TransactionProto { transaction };
-
-        // Submit the transaction to the chosen workers.
-        for tx_client in &mut tx_clients {
-            tx_client.submit_transaction(tx.clone()).await.unwrap();
+        // Submit the transactions to the workers.
+        let mut clients = tx_clients.clone();
+        if timeout(
+            Duration::from_secs(3),
+            tokio::spawn(async move {
+                for tx in tx_batch {
+                    for tx_client in &mut clients {
+                        tx_client.submit_transaction(tx.clone()).await.unwrap();
+                    }
+                }
+            }),
+        )
+        .await
+        .is_err()
+        {
+            if i == MAX_FAILURES + 1 {
+                // Once the maximum number of primary failures is breached, a timeout is expected.
+                break;
+            } else {
+                panic!("Unexpected transaction transmission timeout at {i} failures instead of {}", MAX_FAILURES + 1);
+            }
         }
-    }
 
-    // Wait for a while to allow the transfers to be processed.
-    tokio::time::sleep(Duration::from_secs(3)).await;
+        // Wait for the transfers to be processed by everyone.
+        let states = running_consensus_instances.iter().map(|rci| rci.state.clone()).collect::<Vec<_>>();
+        // Use a generous timeout in case many primaries are tested.
+        deadline!(Duration::from_secs(10), move || {
+            let mut states = states.iter();
+            let first_tx_count = states.next().unwrap().processed_txs.load(Ordering::SeqCst);
 
-    // Save the current numbers for processed transactions.
-    let tx_counts1 = running_consensus_instances
-        .iter()
-        .map(|rci| rci.state.processed_txs.load(Ordering::SeqCst))
-        .collect::<Vec<_>>();
+            if first_tx_count == tx_count_before_batch {
+                return false;
+            }
 
-    // Kill one of the consensus instances and shut down the corresponding transaction client.
-    let instance_idx = rng.gen_range(0..NUM_PRIMARIES);
-    let instance = running_consensus_instances.remove(instance_idx);
+            states.map(|state| state.processed_txs.load(Ordering::SeqCst)).all(|tx_count| tx_count == first_tx_count)
+        });
 
-    instance.primary_node.shutdown().await;
-    drop(instance);
-    tx_clients.remove(instance_idx);
-
-    // Send another third of the transactions to the workers.
-    for transfer in &transfers[10..20] {
-        let transaction: Bytes = bincode::serialize(&transfer).unwrap().into();
-        let tx = TransactionProto { transaction };
-
-        // Submit the transaction to the chosen workers.
-        for tx_client in &mut tx_clients {
-            tx_client.submit_transaction(tx.clone()).await.unwrap();
+        // Kill one of the consensus instances and shut down the corresponding transaction client.
+        let instance_idx = rng.gen_range(0..NUM_PRIMARIES - i);
+        let instance = running_consensus_instances.swap_remove(instance_idx);
+        for worker_node in &instance.worker_nodes {
+            worker_node.shutdown().await;
         }
-    }
-
-    // Wait for a while to allow the transfers to be processed.
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
-    // Save the current numbers for processed transactions.
-    let tx_counts2 = running_consensus_instances
-        .iter()
-        .map(|rci| rci.state.processed_txs.load(Ordering::SeqCst))
-        .collect::<Vec<_>>();
-
-    // First check: the processed tx counts should have changed, as a single missing primary shouldn't break the consensus.
-    for (count1, count2) in tx_counts1.iter().zip(&tx_counts2) {
-        assert!(count2 > count1);
-    }
-
-    // Kill another one of the primaries and shut down the corresponding transaction client.
-    let instance_idx = rng.gen_range(0..NUM_PRIMARIES - 1);
-    let instance = running_consensus_instances.remove(instance_idx);
-    // FIXME: this shouldn't need to happen in a separate task, but the await hangs otherwise.
-    tokio::spawn(async move {
         instance.primary_node.shutdown().await;
-    });
-    tx_clients.remove(instance_idx);
-
-    // Send another third of the transactions to the workers.
-    for transfer in &transfers[20..] {
-        let transaction: Bytes = bincode::serialize(&transfer).unwrap().into();
-        let tx = TransactionProto { transaction };
-
-        // Submit the transaction to the chosen workers.
-        for tx_client in &mut tx_clients {
-            tx_client.submit_transaction(tx.clone()).await.unwrap();
-        }
+        drop(instance);
+        // This index matches the consensus instance one due to us sorting the clients by the port.
+        tx_clients.swap_remove(instance_idx);
     }
-
-    // Wait for a while to allow the transfers to be processed.
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
-    // Save the current numbers for processed transactions.
-    let tx_counts3 = running_consensus_instances
-        .iter()
-        .map(|rci| rci.state.processed_txs.load(Ordering::SeqCst))
-        .collect::<Vec<_>>();
-
-    // Final check: the processed tx counts should NOT have changed, as another missing primary should break the consensus.
-    assert_eq!(tx_counts3, &tx_counts2[..2]);
 }

--- a/node/bft-consensus/tests/common/state.rs
+++ b/node/bft-consensus/tests/common/state.rs
@@ -147,8 +147,10 @@ impl ExecutionState for TestBftExecutionState {
         let round = consensus_output.sub_dag.round();
         let sdi = consensus_output.sub_dag.sub_dag_index;
         let nb = consensus_output.sub_dag.num_batches();
+
         info!("Consensus [leader: {leader}, round: {round}, sdi: {sdi}, num_batches: {nb}]:");
 
+        // Return early if there's no transactions.
         if consensus_output.batches.is_empty() {
             return;
         }
@@ -162,7 +164,6 @@ impl ExecutionState for TestBftExecutionState {
                 }
             }
         }
-
         self.process_transactions(transactions);
     }
 

--- a/node/bft-consensus/tests/common/state.rs
+++ b/node/bft-consensus/tests/common/state.rs
@@ -141,8 +141,15 @@ impl TestBftExecutionState {
 #[async_trait]
 impl ExecutionState for TestBftExecutionState {
     async fn handle_consensus_output(&self, consensus_output: ConsensusOutput) {
+        // Register and log some useful information.
+        let mut leader = consensus_output.sub_dag.leader.header.author.to_string();
+        leader.truncate(8);
+        let round = consensus_output.sub_dag.round();
+        let sdi = consensus_output.sub_dag.sub_dag_index;
+        let nb = consensus_output.sub_dag.num_batches();
+        info!("Consensus [leader: {leader}, round: {round}, sdi: {sdi}, num_batches: {nb}]:");
+
         if consensus_output.batches.is_empty() {
-            info!("There are no batches to process.");
             return;
         }
 


### PR DESCRIPTION
This PR extends the `primary_failures` test; it is now possible to alter the value of `NUM_PRIMARIES` ad-hoc.

In addition, the test logs are extended a little bit.