### PR TITLE
Testnet3 Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,7 +2766,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -2787,6 +2787,24 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem"
 version = "0.11.0"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
+dependencies = [
+ "cfg-if",
+ "ed25519-consensus",
+ "fastcrypto",
+ "hashbrown 0.12.3",
+ "impl-trait-for-tuples",
+ "indexmap",
+ "mysten-util-mem-derive 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "once_cell",
+ "parking_lot",
+ "roaring",
+ "smallvec",
+]
+
+[[package]]
+name = "mysten-util-mem"
+version = "0.11.0"
 source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
 dependencies = [
  "cfg-if",
@@ -2795,11 +2813,21 @@ dependencies = [
  "hashbrown 0.12.3",
  "impl-trait-for-tuples",
  "indexmap",
- "mysten-util-mem-derive",
+ "mysten-util-mem-derive 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
  "once_cell",
  "parking_lot",
  "roaring",
  "smallvec",
+]
+
+[[package]]
+name = "mysten-util-mem-derive"
+version = "0.1.0"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
+dependencies = [
+ "proc-macro2 1.0.51",
+ "syn 1.0.107",
+ "synstructure",
 ]
 
 [[package]]
@@ -2815,13 +2843,31 @@ dependencies = [
 [[package]]
 name = "narwhal-config"
 version = "0.1.0"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
+dependencies = [
+ "arc-swap",
+ "fastcrypto",
+ "match_opt",
+ "multiaddr",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "narwhal-config"
+version = "0.1.0"
 source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
 dependencies = [
  "arc-swap",
  "fastcrypto",
  "match_opt",
  "multiaddr",
- "narwhal-crypto",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
  "rand",
  "serde",
  "serde_json",
@@ -2833,7 +2879,7 @@ dependencies = [
 [[package]]
 name = "narwhal-consensus"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",
@@ -2841,18 +2887,38 @@ dependencies = [
  "cfg-if",
  "fastcrypto",
  "match_opt",
- "mysten-util-mem",
- "narwhal-config",
- "narwhal-crypto",
- "narwhal-dag",
+ "metrics",
+ "mysten-util-mem 0.11.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-dag 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-storage",
- "narwhal-types",
+ "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "rand",
  "serde",
+ "snarkos-node-metrics 2.0.2 (git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics)",
  "thiserror",
  "tokio",
  "tracing",
- "typed-store",
+ "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+]
+
+[[package]]
+name = "narwhal-crypto"
+version = "0.1.0"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+dependencies = [
+ "eyre",
+ "fastcrypto",
+ "merlin",
+ "once_cell",
+ "rand",
+ "readonly",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "tokio",
+ "zeroize",
 ]
 
 [[package]]
@@ -2876,14 +2942,31 @@ dependencies = [
 [[package]]
 name = "narwhal-dag"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
 dependencies = [
  "arc-swap",
  "dashmap",
  "either",
  "fastcrypto",
  "itertools",
- "narwhal-crypto",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "once_cell",
+ "rayon",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "narwhal-dag"
+version = "0.1.0"
+source = "git+https://github.com/eqlabs/bullshark-bft/#6e84df89eef18b79b19629b1bf83a941b6237b77"
+dependencies = [
+ "arc-swap",
+ "dashmap",
+ "either",
+ "fastcrypto",
+ "itertools",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
  "once_cell",
  "rayon",
  "serde",
@@ -2893,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "narwhal-executor"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -2908,13 +2991,13 @@ dependencies = [
  "match_opt",
  "mockall",
  "multiaddr",
- "narwhal-config",
+ "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-consensus",
- "narwhal-crypto",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-network",
  "narwhal-primary",
  "narwhal-storage",
- "narwhal-types",
+ "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "rand",
  "serde",
  "tap",
@@ -2923,13 +3006,13 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tracing",
- "typed-store",
+ "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
 ]
 
 [[package]]
 name = "narwhal-network"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -2943,11 +3026,13 @@ dependencies = [
  "fail",
  "fastcrypto",
  "futures",
+ "metrics",
  "multiaddr",
- "narwhal-crypto",
- "narwhal-types",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "rand",
  "serde",
+ "snarkos-node-metrics 2.0.2 (git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics)",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2959,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "narwhal-node"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
 dependencies = [
  "anemo",
  "anyhow",
@@ -2978,14 +3063,14 @@ dependencies = [
  "itertools",
  "multiaddr",
  "mysten-network",
- "narwhal-config",
+ "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-consensus",
- "narwhal-crypto",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-executor",
  "narwhal-network",
  "narwhal-primary",
  "narwhal-storage",
- "narwhal-types",
+ "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-worker",
  "once_cell",
  "rand",
@@ -3002,14 +3087,14 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber 0.3.16",
- "typed-store",
+ "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "url",
 ]
 
 [[package]]
 name = "narwhal-primary"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3029,12 +3114,12 @@ dependencies = [
  "itertools",
  "multiaddr",
  "mysten-network",
- "narwhal-config",
+ "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-consensus",
- "narwhal-crypto",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-network",
  "narwhal-storage",
- "narwhal-types",
+ "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "once_cell",
  "prost",
  "rand",
@@ -3047,28 +3132,70 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "typed-store",
+ "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
 ]
 
 [[package]]
 name = "narwhal-storage"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
 dependencies = [
  "dashmap",
  "fail",
  "fastcrypto",
  "futures",
- "narwhal-config",
- "narwhal-crypto",
- "narwhal-types",
+ "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",
  "tonic",
  "tracing",
- "typed-store",
+ "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+]
+
+[[package]]
+name = "narwhal-types"
+version = "0.1.0"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+dependencies = [
+ "anemo",
+ "anemo-build",
+ "async-trait",
+ "base64 0.13.1",
+ "bincode 1.3.3",
+ "bytes",
+ "dashmap",
+ "derive_builder",
+ "fastcrypto",
+ "futures",
+ "indexmap",
+ "mockall",
+ "mysten-util-mem 0.11.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-dag 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "prost",
+ "prost-build",
+ "protobuf-src",
+ "rand",
+ "roaring",
+ "rustversion",
+ "serde",
+ "serde_with",
+ "signature 1.6.4",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
 ]
 
 [[package]]
@@ -3088,10 +3215,10 @@ dependencies = [
  "futures",
  "indexmap",
  "mockall",
- "mysten-util-mem",
- "narwhal-config",
- "narwhal-crypto",
- "narwhal-dag",
+ "mysten-util-mem 0.11.0 (git+https://github.com/eqlabs/bullshark-bft/)",
+ "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
+ "narwhal-dag 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -3110,13 +3237,13 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
- "typed-store",
+ "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/)",
 ]
 
 [[package]]
 name = "narwhal-worker"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3130,10 +3257,10 @@ dependencies = [
  "governor",
  "multiaddr",
  "mysten-network",
- "narwhal-config",
- "narwhal-crypto",
+ "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-network",
- "narwhal-types",
+ "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "rand",
  "serde",
  "tap",
@@ -3143,7 +3270,7 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "typed-store",
+ "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
 ]
 
 [[package]]
@@ -4800,7 +4927,7 @@ dependencies = [
  "fastcrypto",
  "futures-util",
  "indexmap",
- "narwhal-types",
+ "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -4814,6 +4941,7 @@ dependencies = [
  "snarkos-node-consensus",
  "snarkos-node-ledger",
  "snarkos-node-messages",
+ "snarkos-node-metrics 2.0.2",
  "snarkos-node-rest",
  "snarkos-node-router",
  "snarkos-node-store",
@@ -4840,11 +4968,11 @@ dependencies = [
  "deadline",
  "fastcrypto",
  "multiaddr",
- "narwhal-config",
- "narwhal-crypto",
+ "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-executor",
  "narwhal-node",
- "narwhal-types",
+ "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
  "narwhal-worker",
  "parking_lot",
  "rand",
@@ -4889,7 +5017,7 @@ dependencies = [
  "bytes",
  "indexmap",
  "multiaddr",
- "narwhal-types",
+ "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
  "once_cell",
  "parking_lot",
  "rand",
@@ -4943,6 +5071,16 @@ dependencies = [
 [[package]]
 name = "snarkos-node-metrics"
 version = "2.0.2"
+dependencies = [
+ "metrics",
+ "metrics-exporter-prometheus",
+ "tokio",
+]
+
+[[package]]
+name = "snarkos-node-metrics"
+version = "2.0.2"
+source = "git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics#b70a1f589dba3ec745477dc904d493efb0d31190"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -5769,7 +5907,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "crossterm 0.25.0",
  "once_cell",
@@ -6323,7 +6461,30 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+dependencies = [
+ "async-trait",
+ "bincode 1.3.3",
+ "collectable",
+ "eyre",
+ "fdlimit",
+ "hdrhistogram",
+ "num_cpus",
+ "once_cell",
+ "ouroboros",
+ "rand",
+ "rocksdb",
+ "serde",
+ "tap",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "typed-store"
+version = "0.4.0"
+source = "git+https://github.com/eqlabs/bullshark-bft/#6e84df89eef18b79b19629b1bf83a941b6237b77"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "narwhal-consensus"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",
@@ -2860,7 +2860,7 @@ dependencies = [
 [[package]]
 name = "narwhal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "eyre",
  "fastcrypto",
@@ -2878,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "narwhal-dag"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "arc-swap",
  "dashmap",
@@ -2895,7 +2895,7 @@ dependencies = [
 [[package]]
 name = "narwhal-executor"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -2933,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "narwhal-network"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "narwhal-node"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "narwhal-primary"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3061,7 +3061,7 @@ dependencies = [
 [[package]]
 name = "narwhal-storage"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "dashmap",
  "fail",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "narwhal-types"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "narwhal-worker"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6342,7 +6342,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,25 +2795,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "impl-trait-for-tuples",
  "indexmap",
- "mysten-util-mem-derive 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "once_cell",
- "parking_lot",
- "roaring",
- "smallvec",
-]
-
-[[package]]
-name = "mysten-util-mem"
-version = "0.11.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
-dependencies = [
- "cfg-if",
- "ed25519-consensus",
- "fastcrypto",
- "hashbrown 0.12.3",
- "impl-trait-for-tuples",
- "indexmap",
- "mysten-util-mem-derive 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
+ "mysten-util-mem-derive",
  "once_cell",
  "parking_lot",
  "roaring",
@@ -2831,16 +2813,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mysten-util-mem-derive"
-version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
-dependencies = [
- "proc-macro2 1.0.51",
- "syn 1.0.107",
- "synstructure",
-]
-
-[[package]]
 name = "narwhal-config"
 version = "0.1.0"
 source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#e064a8761a0c5bc27f9196f1e1fff6ada869fe59"
@@ -2849,25 +2821,7 @@ dependencies = [
  "fastcrypto",
  "match_opt",
  "multiaddr",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "rand",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "narwhal-config"
-version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
-dependencies = [
- "arc-swap",
- "fastcrypto",
- "match_opt",
- "multiaddr",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
+ "narwhal-crypto",
  "rand",
  "serde",
  "serde_json",
@@ -2879,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "narwhal-consensus"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",
@@ -2888,43 +2842,25 @@ dependencies = [
  "fastcrypto",
  "match_opt",
  "metrics",
- "mysten-util-mem 0.11.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-dag 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "mysten-util-mem",
+ "narwhal-config",
+ "narwhal-crypto",
+ "narwhal-dag",
  "narwhal-storage",
- "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-types",
  "rand",
  "serde",
  "snarkos-node-metrics 2.0.2 (git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics)",
  "thiserror",
  "tokio",
  "tracing",
- "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "typed-store",
 ]
 
 [[package]]
 name = "narwhal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
-dependencies = [
- "eyre",
- "fastcrypto",
- "merlin",
- "once_cell",
- "rand",
- "readonly",
- "serde",
- "serde_bytes",
- "serde_with",
- "tokio",
- "zeroize",
-]
-
-[[package]]
-name = "narwhal-crypto"
-version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "eyre",
  "fastcrypto",
@@ -2942,31 +2878,14 @@ dependencies = [
 [[package]]
 name = "narwhal-dag"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "arc-swap",
  "dashmap",
  "either",
  "fastcrypto",
  "itertools",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "once_cell",
- "rayon",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "narwhal-dag"
-version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#6e84df89eef18b79b19629b1bf83a941b6237b77"
-dependencies = [
- "arc-swap",
- "dashmap",
- "either",
- "fastcrypto",
- "itertools",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
+ "narwhal-crypto",
  "once_cell",
  "rayon",
  "serde",
@@ -2976,7 +2895,7 @@ dependencies = [
 [[package]]
 name = "narwhal-executor"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -2989,30 +2908,32 @@ dependencies = [
  "futures",
  "itertools",
  "match_opt",
+ "metrics",
  "mockall",
  "multiaddr",
- "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-config",
  "narwhal-consensus",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-crypto",
  "narwhal-network",
  "narwhal-primary",
  "narwhal-storage",
- "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-types",
  "rand",
  "serde",
+ "snarkos-node-metrics 2.0.2 (git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics)",
  "tap",
  "thiserror",
  "tokio",
  "tokio-util",
  "tonic",
  "tracing",
- "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "typed-store",
 ]
 
 [[package]]
 name = "narwhal-network"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3028,8 +2949,8 @@ dependencies = [
  "futures",
  "metrics",
  "multiaddr",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-crypto",
+ "narwhal-types",
  "rand",
  "serde",
  "snarkos-node-metrics 2.0.2 (git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics)",
@@ -3044,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "narwhal-node"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3063,14 +2984,14 @@ dependencies = [
  "itertools",
  "multiaddr",
  "mysten-network",
- "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-config",
  "narwhal-consensus",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-crypto",
  "narwhal-executor",
  "narwhal-network",
  "narwhal-primary",
  "narwhal-storage",
- "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-types",
  "narwhal-worker",
  "once_cell",
  "rand",
@@ -3087,14 +3008,14 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber 0.3.16",
- "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "typed-store",
  "url",
 ]
 
 [[package]]
 name = "narwhal-primary"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3112,19 +3033,21 @@ dependencies = [
  "futures",
  "governor",
  "itertools",
+ "metrics",
  "multiaddr",
  "mysten-network",
- "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-config",
  "narwhal-consensus",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-crypto",
  "narwhal-network",
  "narwhal-storage",
- "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-types",
  "once_cell",
  "prost",
  "rand",
  "roaring",
  "serde",
+ "snarkos-node-metrics 2.0.2 (git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics)",
  "tap",
  "thiserror",
  "tokio",
@@ -3132,34 +3055,34 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "typed-store",
 ]
 
 [[package]]
 name = "narwhal-storage"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "dashmap",
  "fail",
  "fastcrypto",
  "futures",
- "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-config",
+ "narwhal-crypto",
+ "narwhal-types",
  "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",
  "tonic",
  "tracing",
- "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "typed-store",
 ]
 
 [[package]]
 name = "narwhal-types"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -3173,10 +3096,10 @@ dependencies = [
  "futures",
  "indexmap",
  "mockall",
- "mysten-util-mem 0.11.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-dag 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "mysten-util-mem",
+ "narwhal-config",
+ "narwhal-crypto",
+ "narwhal-dag",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -3195,55 +3118,13 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
- "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
-]
-
-[[package]]
-name = "narwhal-types"
-version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#eed1f0fec04d0f17a1dea15958792d5419bd1823"
-dependencies = [
- "anemo",
- "anemo-build",
- "async-trait",
- "base64 0.13.1",
- "bincode 1.3.3",
- "bytes",
- "dashmap",
- "derive_builder",
- "fastcrypto",
- "futures",
- "indexmap",
- "mockall",
- "mysten-util-mem 0.11.0 (git+https://github.com/eqlabs/bullshark-bft/)",
- "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
- "narwhal-dag 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
- "once_cell",
- "proptest",
- "proptest-derive",
- "prost",
- "prost-build",
- "protobuf-src",
- "rand",
- "roaring",
- "rustversion",
- "serde",
- "serde_with",
- "signature 1.6.4",
- "thiserror",
- "tokio",
- "tokio-util",
- "tonic",
- "tonic-build",
- "tracing",
- "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/)",
+ "typed-store",
 ]
 
 [[package]]
 name = "narwhal-worker"
 version = "0.1.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3257,10 +3138,10 @@ dependencies = [
  "governor",
  "multiaddr",
  "mysten-network",
- "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-config",
+ "narwhal-crypto",
  "narwhal-network",
- "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-types",
  "rand",
  "serde",
  "tap",
@@ -3270,7 +3151,7 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "typed-store 0.4.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "typed-store",
 ]
 
 [[package]]
@@ -4927,7 +4808,7 @@ dependencies = [
  "fastcrypto",
  "futures-util",
  "indexmap",
- "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-types",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -4968,11 +4849,11 @@ dependencies = [
  "deadline",
  "fastcrypto",
  "multiaddr",
- "narwhal-config 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
- "narwhal-crypto 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-config",
+ "narwhal-crypto",
  "narwhal-executor",
  "narwhal-node",
- "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics)",
+ "narwhal-types",
  "narwhal-worker",
  "parking_lot",
  "rand",
@@ -5017,7 +4898,7 @@ dependencies = [
  "bytes",
  "indexmap",
  "multiaddr",
- "narwhal-types 0.1.0 (git+https://github.com/eqlabs/bullshark-bft/)",
+ "narwhal-types",
  "once_cell",
  "parking_lot",
  "rand",
@@ -6461,30 +6342,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#b635ca4205b8039919e7a49fbb05ea11331ec220"
-dependencies = [
- "async-trait",
- "bincode 1.3.3",
- "collectable",
- "eyre",
- "fdlimit",
- "hdrhistogram",
- "num_cpus",
- "once_cell",
- "ouroboros",
- "rand",
- "rocksdb",
- "serde",
- "tap",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "typed-store"
-version = "0.4.0"
-source = "git+https://github.com/eqlabs/bullshark-bft/#6e84df89eef18b79b19629b1bf83a941b6237b77"
+source = "git+https://github.com/eqlabs/bullshark-bft/?branch=feat/metrics#c99fe69532f6c5d75b0d22b617a6edeecce90b95"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,14 @@ members = [
 name = "snarkos"
 path = "snarkos/main.rs"
 
+[workspace.dependencies]
+narwhal-types       = { git = "https://github.com/eqlabs/bullshark-bft/", branch = "feat/metrics", package = "narwhal-types" }
+narwhal-config      = { git = "https://github.com/eqlabs/bullshark-bft/", branch = "feat/metrics", package = "narwhal-config" }
+narwhal-crypto      = { git = "https://github.com/eqlabs/bullshark-bft/", branch = "feat/metrics", package = "narwhal-crypto" }
+narwhal-executor    = { git = "https://github.com/eqlabs/bullshark-bft/", branch = "feat/metrics", package = "narwhal-executor" }
+narwhal-node        = { git = "https://github.com/eqlabs/bullshark-bft/", branch = "feat/metrics", package = "narwhal-node"}
+narwhal-worker      = { git = "https://github.com/eqlabs/bullshark-bft/", branch = "feat/metrics", package = "narwhal-worker"}
+
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 #git = "https://github.com/AleoHQ/snarkVM.git"
@@ -112,6 +120,7 @@ debug-assertions = false
 opt-level = 2
 lto = "thin"
 incremental = true
+split-debuginfo = "unpacked"
 
 [profile.test]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,6 @@ debug-assertions = false
 opt-level = 2
 lto = "thin"
 incremental = true
-split-debuginfo = "unpacked"
 
 [profile.test]
 opt-level = 2

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -85,6 +85,9 @@ pub struct Start {
     /// Specify the path to the file where logs will be stored.
     #[clap(default_value_os_t = std::env::temp_dir().join("snarkos.log"), long = "logfile")]
     pub logfile: PathBuf,
+
+    #[clap(long = "metrics", action)]
+    pub metrics: bool,
 }
 
 impl Start {
@@ -297,7 +300,7 @@ impl Start {
         // Initialize the node.
         match node_type {
             NodeType::Beacon => Node::new_beacon(self.node, rest_ip, account, &trusted_peers, genesis, cdn, self.dev).await,
-            NodeType::Validator => Node::new_validator(self.node, rest_ip, account, &trusted_peers, genesis, cdn, self.dev).await,
+            NodeType::Validator => Node::new_validator(self.node, rest_ip, account, &trusted_peers, genesis, cdn, self.dev, self.metrics).await,
             NodeType::Prover => Node::new_prover(self.node, account, &trusted_peers, genesis, self.dev).await,
             NodeType::Client => Node::new_client(self.node, account, &trusted_peers, genesis, self.dev).await,
         }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2021"
 default = []
 test = []
 timer = [ "aleo-std/timer", "snarkos-node-ledger/timer" ]
+metrics = ["snarkos-node-bft-consensus/metrics"]
 
 [dependencies] # added for BFT
 narwhal-types.workspace = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,12 +17,12 @@ license = "GPL-3.0"
 edition = "2021"
 
 [features]
-default = [ ]
+default = []
 test = []
 timer = [ "aleo-std/timer", "snarkos-node-ledger/timer" ]
 
 [dependencies] # added for BFT
-narwhal-types = { git = "https://github.com/eqlabs/bullshark-bft/", package = "narwhal-types" }
+narwhal-types.workspace = true
 bytes = "1.4.0"
 tonic = "0.8.3"
 
@@ -83,6 +83,9 @@ path = "./ledger"
 
 [dependencies.snarkos-node-messages]
 path = "./messages"
+
+[dependencies.snarkos-node-metrics]
+path = "./metrics"
 
 [dependencies.snarkos-node-rest]
 path = "./rest"

--- a/node/bft-consensus/Cargo.toml
+++ b/node/bft-consensus/Cargo.toml
@@ -25,12 +25,12 @@ snarkos-node-tcp = { path = "../tcp" }
 snarkvm = { workspace = true }
 
 # below are the dependencies for BFT
-narwhal-config = { git = "https://github.com/eqlabs/bullshark-bft/", package = "narwhal-config" }
-narwhal-crypto = { git = "https://github.com/eqlabs/bullshark-bft/", package = "narwhal-crypto" }
-narwhal-executor = { git = "https://github.com/eqlabs/bullshark-bft/", package = "narwhal-executor" }
-narwhal-node = { git = "https://github.com/eqlabs/bullshark-bft/", package = "narwhal-node"}
-narwhal-worker = { git = "https://github.com/eqlabs/bullshark-bft/", package = "narwhal-worker"}
-narwhal-types = { git = "https://github.com/eqlabs/bullshark-bft/", package = "narwhal-types" }
+narwhal-config.workspace = true
+narwhal-crypto.workspace = true
+narwhal-executor.workspace = true
+narwhal-node.workspace = true
+narwhal-worker.workspace = true
+narwhal-types.workspace = true
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 arc-swap = "1.5.1"

--- a/node/bft-consensus/Cargo.toml
+++ b/node/bft-consensus/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+metrics = ["narwhal-node/metrics", "narwhal-executor/metrics"]
 test = []
 
 [dependencies]

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [features]
 default = [ "parallel" ]
 parallel = [ "rayon" ]
+metrics = [ "snarkos-node/metrics" ]
 
 [dependencies.anyhow]
 version = "1"

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -59,8 +59,7 @@ version = "1"
 version = "0.17"
 
 [dev-dependencies.narwhal-types]
-git = "https://github.com/eqlabs/bullshark-bft/"
-package = "narwhal-types"
+workspace = true
 
 [dev-dependencies.snarkos-account]
 path = "../../account"

--- a/node/consensus/src/tests.rs
+++ b/node/consensus/src/tests.rs
@@ -563,6 +563,7 @@ async fn test_bullshark_full() {
             genesis.clone(), // use a common genesis block
             None,
             Some(i as u16),
+            false,
         )
         .await
         .unwrap();

--- a/node/consensus/src/tests.rs
+++ b/node/consensus/src/tests.rs
@@ -563,7 +563,7 @@ async fn test_bullshark_full() {
             genesis.clone(), // use a common genesis block
             None,
             Some(i as u16),
-            false,
+            i == 0, // enable metrics only for the first validator
         )
         .await
         .unwrap();

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -45,4 +45,10 @@ fn register_metrics() {
     for name in GAUGE_NAMES {
         register_gauge!(name);
     }
+    for name in COUNTER_NAMES {
+        register_counter!(name);
+    }
+    for name in HISTOGRAM_NAMES {
+        register_histogram!(name);
+    }
 }

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -14,7 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub const GAUGE_NAMES: [&str; 4] = [blocks::HEIGHT, peers::CONNECTED, peers::CANDIDATE, peers::RESTRICTED];
+pub const GAUGE_NAMES: [&str; 5] =
+    [blocks::HEIGHT, peers::CONNECTED, peers::CANDIDATE, peers::RESTRICTED, consensus::CERTIFICATE_COMMIT_LATENCY];
+pub const COUNTER_NAMES: [&str; 3] =
+    [consensus::LEADERS_ELECTED, consensus::LAST_COMMITTED_ROUND, consensus::COMMITTED_CERTIFICATES];
+pub const HISTOGRAM_NAMES: [&str; 1] = [network::NETWORK_PEERS];
 
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
@@ -24,4 +28,20 @@ pub mod peers {
     pub const CONNECTED: &str = "snarkos_peers_connected_total";
     pub const CANDIDATE: &str = "snarkos_peers_candidate_total";
     pub const RESTRICTED: &str = "snarkos_peers_restricted_total";
+}
+
+pub mod consensus {
+    pub const COMMITTED_CERTIFICATES: &str = "snarkos_consensus_committed_certificates_total";
+    pub const CERTIFICATE_COMMIT_LATENCY: &str = "snarkos_consensus_certificate_commit_latency_secs";
+    pub const LEADERS_ELECTED: &str = "snarkos_consensus_leaders_elected_total";
+    pub const LAST_COMMITTED_ROUND: &str = "snarkos_consensus_last_committed_round";
+}
+
+pub mod network {
+    pub const NETWORK_PEERS: &str = "snarkos_network_peers_connected_total";
+    pub const NETWORK_PEER_CONNECTED: &str = "snarkos_network_peer_connected";
+
+    pub mod labels {
+        pub const PEER_ID: &str = "peer_id";
+    }
 }

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -19,13 +19,14 @@ pub const GAUGE_NAMES: [&str; 8] = [
     peers::CONNECTED,
     peers::CANDIDATE,
     peers::RESTRICTED,
-    consensus::CERTIFICATE_COMMIT_LATENCY,
     consensus::COMMITTED_CERTIFICATES,
     consensus::LAST_COMMITTED_ROUND,
     network::NETWORK_PEERS,
+    primary::CURRENT_ROUND,
 ];
 pub const COUNTER_NAMES: [&str; 1] = [consensus::LEADERS_ELECTED];
-pub const HISTOGRAM_NAMES: [&str; 0] = [];
+pub const HISTOGRAM_NAMES: [&str; 3] =
+    [consensus::CERTIFICATE_COMMIT_LATENCY, consensus::COMMIT_ROUNDS_LATENCY, subscribers::CERTIFICATE_LATENCY];
 
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
@@ -40,6 +41,7 @@ pub mod peers {
 pub mod consensus {
     pub const COMMITTED_CERTIFICATES: &str = "snarkos_consensus_committed_certificates_total";
     pub const CERTIFICATE_COMMIT_LATENCY: &str = "snarkos_consensus_certificate_commit_latency_secs";
+    pub const COMMIT_ROUNDS_LATENCY: &str = "snarkos_consensus_commit_rounds_latency_secs";
     pub const LEADERS_ELECTED: &str = "snarkos_consensus_leaders_elected_total";
     pub const LAST_COMMITTED_ROUND: &str = "snarkos_consensus_last_committed_round";
 }
@@ -51,4 +53,12 @@ pub mod network {
     pub mod labels {
         pub const PEER_ID: &str = "peer_id";
     }
+}
+
+pub mod subscribers {
+    pub const CERTIFICATE_LATENCY: &str = "snarkos_subscribers_certificate_latency_secs";
+}
+
+pub mod primary {
+    pub const CURRENT_ROUND: &str = "snarkos_primary_current_round";
 }

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -14,11 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub const GAUGE_NAMES: [&str; 5] =
-    [blocks::HEIGHT, peers::CONNECTED, peers::CANDIDATE, peers::RESTRICTED, consensus::CERTIFICATE_COMMIT_LATENCY];
-pub const COUNTER_NAMES: [&str; 3] =
-    [consensus::LEADERS_ELECTED, consensus::LAST_COMMITTED_ROUND, consensus::COMMITTED_CERTIFICATES];
-pub const HISTOGRAM_NAMES: [&str; 1] = [network::NETWORK_PEERS];
+pub const GAUGE_NAMES: [&str; 8] = [
+    blocks::HEIGHT,
+    peers::CONNECTED,
+    peers::CANDIDATE,
+    peers::RESTRICTED,
+    consensus::CERTIFICATE_COMMIT_LATENCY,
+    consensus::COMMITTED_CERTIFICATES,
+    consensus::LAST_COMMITTED_ROUND,
+    network::NETWORK_PEERS,
+];
+pub const COUNTER_NAMES: [&str; 1] = [consensus::LEADERS_ELECTED];
+pub const HISTOGRAM_NAMES: [&str; 0] = [];
 
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -16,12 +16,12 @@
 
 pub const GAUGE_NAMES: [&str; 8] = [
     blocks::HEIGHT,
-    peers::CONNECTED,
-    peers::CANDIDATE,
-    peers::RESTRICTED,
     consensus::COMMITTED_CERTIFICATES,
     consensus::LAST_COMMITTED_ROUND,
     network::NETWORK_PEERS,
+    peers::CANDIDATE,
+    peers::CONNECTED,
+    peers::RESTRICTED,
     primary::CURRENT_ROUND,
 ];
 pub const COUNTER_NAMES: [&str; 1] = [consensus::LEADERS_ELECTED];

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -82,9 +82,10 @@ impl<N: Network> Node<N> {
         genesis: Block<N>,
         cdn: Option<String>,
         dev: Option<u16>,
+        enable_metrics: bool,
     ) -> Result<Self> {
         Ok(Self::Validator(Arc::new(
-            Validator::new(node_ip, rest_ip, account, trusted_peers, genesis, cdn, dev).await?,
+            Validator::new(node_ip, rest_ip, account, trusted_peers, genesis, cdn, dev, enable_metrics).await?,
         )))
     }
 

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -81,6 +81,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         genesis: Block<N>,
         cdn: Option<String>,
         dev: Option<u16>,
+        enable_metrics: bool,
     ) -> Result<Self> {
         // Initialize the ledger.
         let ledger = Ledger::load(genesis, dev)?;
@@ -127,6 +128,11 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         node.initialize_routing().await;
         // Initialize the signal handler.
         node.handle_signals();
+        // Initialize metrics.
+        if enable_metrics {
+            info!("Running with metrics enabled.");
+            snarkos_node_metrics::initialize();
+        }
 
         // TODO: isolate the BFT logic below to a new method that is started only once the validator mesh is ready.
 

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -68,6 +68,7 @@ pub async fn validator() -> Validator<CurrentNetwork, ConsensusMemory<CurrentNet
         sample_genesis_block(), // Should load the current network's genesis block.
         None,                   // No CDN.
         Some(0),
+        false,
     )
     .await
     .expect("couldn't create validator instance")

--- a/run-bft.sh
+++ b/run-bft.sh
@@ -7,7 +7,7 @@ function func() {
 	echo "Done"
 }
 
-BEACON_COMMAND="cargo run -- start --nodisplay --verbosity 0 --dev 0 --beacon"
+BEACON_COMMAND="cargo +stable run -- start --nodisplay --verbosity 0 --dev 0 --beacon"
 
 echo "starting beacon as 0, check logs at ./beacon.log"
 $BEACON_COMMAND '' >beacon.log 2>&1 &
@@ -19,7 +19,7 @@ for i in 1 2 3 4; do
 	if [[ "$i" -eq 1 ]]; then
 		extra_args=" --metrics"
 	fi
-	VALIDATOR_COMMAND="cargo run -- start$extra_args --nodisplay --verbosity 0 --dev ${i} --validator"
+	VALIDATOR_COMMAND="cargo +stable run -- start$extra_args --nodisplay --verbosity 0 --dev ${i} --validator"
 	echo "starting validator as $i, check logs at ./validator-$i.log"
 	echo "command: $VALIDATOR_COMMAND"
 	$VALIDATOR_COMMAND '' >validator-$i.log 2>&1 &

--- a/run-bft.sh
+++ b/run-bft.sh
@@ -12,9 +12,16 @@ BEACON_COMMAND="cargo run -- start --nodisplay --verbosity 0 --dev 0 --beacon"
 echo "starting beacon as 0, check logs at ./beacon.log"
 $BEACON_COMMAND '' >beacon.log 2>&1 &
 
+# Start other validators without metrics
 for i in 1 2 3 4; do
-	VALIDATOR_COMMAND="cargo run -- start --nodisplay --verbosity 0 --dev ${i} --validator"
+	# Enable metrics for first validator only
+	extra_args=""
+	if [[ "$i" -eq 1 ]]; then
+		extra_args=" --metrics"
+	fi
+	VALIDATOR_COMMAND="cargo run -- start$extra_args --nodisplay --verbosity 0 --dev ${i} --validator"
 	echo "starting validator as $i, check logs at ./validator-$i.log"
+	echo "command: $VALIDATOR_COMMAND"
 	$VALIDATOR_COMMAND '' >validator-$i.log 2>&1 &
 done
 


### PR DESCRIPTION
# Metrics for narwhal/bullshark consensus

This PR mostly contains plumbing and quality-of-life cli changes.
The actual metrics are implemented here: https://github.com/eqlabs/bullshark-bft/pull/22

## Workspace Dependencies

Narwhal crates currently point to the `feat/metrics` branch. Since changes to both crates have to be kept in sync, I propose adding a follow-up PR to point snarkOS back to the main `bullshark-bft` crate.

## Rebase

Based on https://github.com/eqlabs/snarkOS/pull/7, rebased to `bft_testnet3`.

As part of the rebase, there were quite a few lockfile issues. I fixed them manually and did a `cargo update` afterward to reintegrate missing entries, please keep an eye on those changes when reviewing.