### PR TITLE
BFT test improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,6 +4905,7 @@ dependencies = [
  "rayon",
  "snarkos-account",
  "snarkos-node",
+ "snarkos-node-bft-consensus",
  "snarkos-node-ledger",
  "snarkos-node-messages",
  "snarkvm",

--- a/node/bft-consensus/Cargo.toml
+++ b/node/bft-consensus/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 metrics = ["narwhal-node/metrics", "narwhal-executor/metrics"]
-test = []
+test = ["tempfile"]
 
 [dependencies]
 aleo-std = "0.1.15"
@@ -15,6 +15,7 @@ bytes = "1"
 multiaddr = "0.17"
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
+tempfile = { version = "3", optional = true }
 tokio = { version = "1", features = ["rt"] }
 tonic = "0.8"
 tracing = "0.1.36"
@@ -40,6 +41,5 @@ anyhow = "1"
 [dev-dependencies]
 deadline = "0.2"
 parking_lot = "0.12"
-tempfile = "3"
 tracing-subscriber = "0.3"
 snarkos-node-bft-consensus = { path = ".", features = ["test"] } # a workaround to use the `test` feature in tests by default

--- a/node/bft-consensus/src/lib.rs
+++ b/node/bft-consensus/src/lib.rs
@@ -20,7 +20,7 @@ mod validation;
 
 use setup::*;
 
-pub use state::{sort_transactions, BftExecutionState};
+pub use state::{batched_transactions, sort_transactions, BftExecutionState};
 pub use validation::TransactionValidator;
 
 use anyhow::Result;

--- a/node/bft-consensus/src/setup.rs
+++ b/node/bft-consensus/src/setup.rs
@@ -21,6 +21,7 @@ use std::{
     sync::atomic::Ordering,
 };
 
+#[cfg(not(feature = "test"))]
 use aleo_std::aleo_dir;
 use anyhow::anyhow;
 use fastcrypto::{
@@ -244,6 +245,7 @@ impl CommitteeSetup {
 }
 
 // Returns the base path for the BFT storage files.
+#[cfg(not(feature = "test"))]
 fn base_storage_path(dev: Option<u16>) -> PathBuf {
     // Retrieve the starting directory.
     match dev.is_some() {
@@ -252,6 +254,15 @@ fn base_storage_path(dev: Option<u16>) -> PathBuf {
         // In production mode, the ledger is stored in the `~/.aleo/` directory.
         false => aleo_dir(),
     }
+}
+
+// Returns the base path for the BFT storage files.
+#[cfg(feature = "test")]
+fn base_storage_path(_dev: Option<u16>) -> PathBuf {
+    // The call to `into_path` causes the directory to not be deleted afterwards,
+    // but it resides in the system's temporary file directory, so it gets removed
+    // soon regardless.
+    tempfile::TempDir::new().unwrap().into_path()
 }
 
 // Returns the path for the primary-related BFT files.

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -84,3 +84,8 @@ version = "0.3"
 
 [dev-dependencies.tracing-test]
 version = "0.2"
+
+# a workaround to use the `test` feature in tests by default
+[dev-dependencies.snarkos-node-bft-consensus]
+path = "../bft-consensus"
+features = ["test"]

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-use snarkos_node_bft_consensus::sort_transactions;
+use snarkos_node_bft_consensus::{batched_transactions, sort_transactions};
 use snarkos_node_messages::{
     BlockRequest,
     BlockResponse,
@@ -180,10 +180,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
 
         // If the previous consensus output is available, check the order of transactions.
         if let Some(last_consensus_output) = self.bft().state.last_output.lock().clone() {
-            let mut expected_txs = last_consensus_output
-                .batches
-                .iter()
-                .flat_map(|batches| batches.1.iter().flat_map(|batch| &batch.transactions))
+            let mut expected_txs = batched_transactions(&last_consensus_output)
                 .map(|bytes| {
                     // Safe; it's our own consensus output, so we already processed this tx with the TransactionValidator.
                     // Also, it's fast to deserialize, because we only process the ID and keep the actual tx as a blob.


### PR DESCRIPTION
This PR contains the following improvements:
- the full node validator tests now use a temporary directory to store the BFT-related files
- a helper function, `batched_transactions`, is added
- the BFT-only test logs were tweaked